### PR TITLE
Allow scrolling over the component's elements

### DIFF
--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -87,6 +87,11 @@ class ReactImageLightbox extends Component {
     }
 
     componentWillMount() {
+        // Prevent scrolling of the background - store value and restore it on unmount
+        var defaultOverflow = document.body.style.overflow;
+        this.setState({ defaultOverflow: defaultOverflow });
+        document.body.style.overflow = "hidden";
+
         // Whether event listeners for keyboard and mouse input have been attached or not
         this.listenersAttached = false;
 
@@ -165,6 +170,9 @@ class ReactImageLightbox extends Component {
     }
 
     componentWillUnmount() {
+        // Reset scrolling of the background
+        document.body.style.overflow = this.state.defaultOverflow;
+
         this.mounted = false;
         this.detachListeners();
     }
@@ -453,10 +461,6 @@ class ReactImageLightbox extends Component {
 
     // Handle a mouse wheel event over the lightbox container
     handleOuterMousewheel(event) {
-        // Prevent scrolling of the background
-        event.preventDefault();
-        event.stopPropagation();
-
         const xThreshold = WHEEL_MOVE_X_THRESHOLD;
         let actionDelay = 0;
         const imageMoveDelay = 500;


### PR DESCRIPTION
Instead of preventing the default behaviour of the mouse-wheel/scrolling event,
set the `overflow` property of body element to `hidden`.
That way we can use the scrolling event to actually scroll on areas of interest.

An example would be to able to scroll over the `imageCaption` area,
when the caption is too large to fit in 150px ( see PR #19 ).