### PR TITLE
Allow server (universal) rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --config webpack.config.dev.babel.js",
     "test": "webpack",
     "lint": "eslint src",
+    "server-test": "node server.js",
     "deploy": "npm run build && gh-pages -d build",
     "prepublish": "npm run lint && npm run build:umd"
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "file-loader": "^0.9.0",
     "gh-pages": "^0.12.0",
     "html-webpack-plugin": "^2.22.0",
+    "isomorphic-style-loader": "^1.1.0",
     "node-sass": "^3.8.0",
     "postcss-loader": "^1.1.0",
     "react": "^15.2.0",
@@ -63,7 +64,6 @@
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.5.3",
     "sass-loader": "^4.0.0",
-    "style-loader": "^0.13.1",
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"
   },

--- a/server.js
+++ b/server.js
@@ -1,0 +1,14 @@
+var React = require('react');
+var ReactDOMServer = require('react-dom/server');
+var LightBox = require('./dist/umd/react-image-lightbox');
+
+console.log(
+  ReactDOMServer.renderToString(
+    React.createElement(LightBox, {
+      mainSrc: '/path/to/foo',
+      prevSrc: '/path/to/foo',
+      nextSrc: '/path/to/foo',
+      onCloseRequest: () => null,
+    })
+  )
+);

--- a/src/examples/cats/app.js
+++ b/src/examples/cats/app.js
@@ -129,6 +129,7 @@ const App = React.createClass({
 
         return (
             <div>
+                <style>{styles._getCss()}</style>
                 <section className={styles['page-header']}>
                     <h1 className={styles['project-name']}>
                         React Image Lightbox

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -1425,135 +1425,138 @@ class ReactImageLightbox extends Component {
         //             zoom-in, zoom-out
 
         return (
-            <Modal
-                isOpen
-                onRequestClose={clickOutsideToClose ? this.requestClose : noop}
-                onAfterOpen={() => this.outerEl && this.outerEl.focus()} // Focus on the div with key handlers
-                style={modalStyle}
-                contentLabel={translate('Lightbox')}
-            >
-                <div // eslint-disable-line jsx-a11y/no-static-element-interactions
-                    // Floating modal with closing animations
-                    className={`outer ril-outer ${styles.outer} ${styles.outerAnimating}` +
-                        (isClosing ? ` closing ril-closing ${styles.outerClosing}` : '')
-                    }
-                    style={{
-                        transition:         `opacity ${animationDuration}ms`,
-                        animationDuration:  `${animationDuration}ms`,
-                        animationDirection: isClosing ? 'normal' : 'reverse',
-                    }}
-                    ref={(el) => { this.outerEl = el; }}
-                    onWheel={this.handleOuterMousewheel}
-                    onMouseMove={this.handleMouseMove}
-                    onMouseDown={this.handleMouseDown}
-                    onTouchStart={this.handleTouchStart}
-                    onTouchMove={this.handleTouchMove}
-                    tabIndex="-1" // Enables key handlers on div
-                    onKeyDown={this.handleKeyInput}
-                    onKeyUp={this.handleKeyInput}
+            <div>
+                <style>{styles._getCss()}</style>
+                <Modal
+                    isOpen
+                    onRequestClose={clickOutsideToClose ? this.requestClose : noop}
+                    onAfterOpen={() => this.outerEl && this.outerEl.focus()} // Focus on the div with key handlers
+                    style={modalStyle}
+                    contentLabel={translate('Lightbox')}
                 >
-
                     <div // eslint-disable-line jsx-a11y/no-static-element-interactions
-                        // Image holder
-                        className={`inner ril-inner ${styles.inner}`}
-                        onClick={clickOutsideToClose ? this.closeIfClickInner : noop}
+                        // Floating modal with closing animations
+                        className={`outer ril-outer ${styles.outer} ${styles.outerAnimating}` +
+                            (isClosing ? ` closing ril-closing ${styles.outerClosing}` : '')
+                        }
+                        style={{
+                            transition:         `opacity ${animationDuration}ms`,
+                            animationDuration:  `${animationDuration}ms`,
+                            animationDirection: isClosing ? 'normal' : 'reverse',
+                        }}
+                        ref={(el) => { this.outerEl = el; }}
+                        onWheel={this.handleOuterMousewheel}
+                        onMouseMove={this.handleMouseMove}
+                        onMouseDown={this.handleMouseDown}
+                        onTouchStart={this.handleTouchStart}
+                        onTouchMove={this.handleTouchMove}
+                        tabIndex="-1" // Enables key handlers on div
+                        onKeyDown={this.handleKeyInput}
+                        onKeyUp={this.handleKeyInput}
                     >
-                        {images}
-                    </div>
 
-                    {prevSrc &&
-                        <button // Move to previous image button
-                            type="button"
-                            className={`prev-button ril-prev-button ${styles.navButtons} ${styles.navButtonPrev}`}
-                            key="prev"
-                            onClick={!this.isAnimating() ? this.requestMovePrev : noop} // Ignore clicks during animation
-                        />
-                    }
-
-                    {nextSrc &&
-                        <button // Move to next image button
-                            type="button"
-                            className={`next-button ril-next-button ${styles.navButtons} ${styles.navButtonNext}`}
-                            key="next"
-                            onClick={!this.isAnimating() ? this.requestMoveNext : noop} // Ignore clicks during animation
-                        />
-                    }
-
-                    <div // Lightbox toolbar
-                        className={`toolbar ril-toolbar ${styles.toolbar}`}
-                    >
-                        <ul className={`toolbar-left ril-toolbar-left ${styles.toolbarSide} ${styles.toolbarLeftSide}`}>
-                            <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
-                                <span className={`ril-toolbar__item__child ${styles.toolbarItemChild}`}>
-                                    {imageTitle}
-                                </span>
-                            </li>
-                        </ul>
-
-                        <ul
-                            className={[
-                                'toolbar-right',
-                                'ril-toolbar-right',
-                                styles.toolbarSide,
-                                styles.toolbarRightSide,
-                            ].join(' ')}
+                        <div // eslint-disable-line jsx-a11y/no-static-element-interactions
+                            // Image holder
+                            className={`inner ril-inner ${styles.inner}`}
+                            onClick={clickOutsideToClose ? this.closeIfClickInner : noop}
                         >
-                            {!toolbarButtons ? '' : toolbarButtons.map((button, i) => (
-                                <li key={i} className={`ril-toolbar__item ${styles.toolbarItem}`}>{button}</li>
-                            ))}
-
-                            {enableZoom &&
-                                <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
-                                    <button // Lightbox zoom in button
-                                        type="button"
-                                        key="zoom-in"
-                                        className={`zoom-in ril-zoom-in ${zoomInButtonClasses.join(' ')}`}
-                                        onClick={zoomInButtonHandler}
-                                    />
-                                </li>
-                            }
-
-                            {enableZoom &&
-                                <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
-                                    <button // Lightbox zoom out button
-                                        type="button"
-                                        key="zoom-out"
-                                        className={`zoom-out ril-zoom-out ${zoomOutButtonClasses.join(' ')}`}
-                                        onClick={zoomOutButtonHandler}
-                                    />
-                                </li>
-                            }
-
-                            <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
-                                <button // Lightbox close button
-                                    type="button"
-                                    key="close"
-                                    className={'close ril-close ril-toolbar__item__child' +
-                                        ` ${styles.toolbarItemChild} ${styles.builtinButton} ${styles.closeButton}`
-                                    }
-                                    onClick={!this.isAnimating() ? this.requestClose : noop} // Ignore clicks during animation
-                                />
-                            </li>
-                        </ul>
-                    </div>
-
-                    {this.props.imageCaption &&
-                        <div // Image caption
-                            onWheel={this.handleCaptionMousewheel}
-                            onMouseDown={event => event.stopPropagation()}
-                            className={`ril-caption ${styles.caption}`}
-                            ref={(el) => { this.caption = el; }}
-                        >
-                            <div
-                                className={`ril-caption-content ${styles.captionContent}`}
-                            >
-                                {this.props.imageCaption}
-                            </div>
+                            {images}
                         </div>
-                    }
 
-                </div>
-            </Modal>
+                        {prevSrc &&
+                            <button // Move to previous image button
+                                type="button"
+                                className={`prev-button ril-prev-button ${styles.navButtons} ${styles.navButtonPrev}`}
+                                key="prev"
+                                onClick={!this.isAnimating() ? this.requestMovePrev : noop} // Ignore clicks during animation
+                            />
+                        }
+
+                        {nextSrc &&
+                            <button // Move to next image button
+                                type="button"
+                                className={`next-button ril-next-button ${styles.navButtons} ${styles.navButtonNext}`}
+                                key="next"
+                                onClick={!this.isAnimating() ? this.requestMoveNext : noop} // Ignore clicks during animation
+                            />
+                        }
+
+                        <div // Lightbox toolbar
+                            className={`toolbar ril-toolbar ${styles.toolbar}`}
+                        >
+                            <ul className={`toolbar-left ril-toolbar-left ${styles.toolbarSide} ${styles.toolbarLeftSide}`}>
+                                <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
+                                    <span className={`ril-toolbar__item__child ${styles.toolbarItemChild}`}>
+                                        {imageTitle}
+                                    </span>
+                                </li>
+                            </ul>
+
+                            <ul
+                                className={[
+                                    'toolbar-right',
+                                    'ril-toolbar-right',
+                                    styles.toolbarSide,
+                                    styles.toolbarRightSide,
+                                ].join(' ')}
+                            >
+                                {!toolbarButtons ? '' : toolbarButtons.map((button, i) => (
+                                    <li key={i} className={`ril-toolbar__item ${styles.toolbarItem}`}>{button}</li>
+                                ))}
+
+                                {enableZoom &&
+                                    <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
+                                        <button // Lightbox zoom in button
+                                            type="button"
+                                            key="zoom-in"
+                                            className={`zoom-in ril-zoom-in ${zoomInButtonClasses.join(' ')}`}
+                                            onClick={zoomInButtonHandler}
+                                        />
+                                    </li>
+                                }
+
+                                {enableZoom &&
+                                    <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
+                                        <button // Lightbox zoom out button
+                                            type="button"
+                                            key="zoom-out"
+                                            className={`zoom-out ril-zoom-out ${zoomOutButtonClasses.join(' ')}`}
+                                            onClick={zoomOutButtonHandler}
+                                        />
+                                    </li>
+                                }
+
+                                <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
+                                    <button // Lightbox close button
+                                        type="button"
+                                        key="close"
+                                        className={'close ril-close ril-toolbar__item__child' +
+                                            ` ${styles.toolbarItemChild} ${styles.builtinButton} ${styles.closeButton}`
+                                        }
+                                        onClick={!this.isAnimating() ? this.requestClose : noop} // Ignore clicks during animation
+                                    />
+                                </li>
+                            </ul>
+                        </div>
+
+                        {this.props.imageCaption &&
+                            <div // Image caption
+                                onWheel={this.handleCaptionMousewheel}
+                                onMouseDown={event => event.stopPropagation()}
+                                className={`ril-caption ${styles.caption}`}
+                                ref={(el) => { this.caption = el; }}
+                            >
+                                <div
+                                    className={`ril-caption-content ${styles.captionContent}`}
+                                >
+                                    {this.props.imageCaption}
+                                </div>
+                            </div>
+                        }
+
+                    </div>
+                </Modal>
+            </div>
         );
     }
 }

--- a/webpack.config.demo.babel.js
+++ b/webpack.config.demo.babel.js
@@ -40,7 +40,7 @@ module.exports = {
             {
                 test: /\.scss$/,
                 loaders: [
-                    'style-loader',
+                    'isomorphic-style-loader',
                     'css-loader?modules&-autoprefixer&importLoaders=1&localIdentName=[local]___[hash:base64:5]',
                     'postcss-loader',
                     'sass-loader',

--- a/webpack.config.dev.babel.js
+++ b/webpack.config.dev.babel.js
@@ -42,7 +42,7 @@ module.exports = {
             {
                 test: /\.scss$/,
                 loaders: [
-                    'style-loader',
+                    'isomorphic-style-loader',
                     'css-loader?modules&-autoprefixer&importLoaders=1&localIdentName=[local]___[hash:base64:5]',
                     'postcss-loader',
                     'sass-loader',

--- a/webpack.config.umd.babel.js
+++ b/webpack.config.umd.babel.js
@@ -48,7 +48,7 @@ module.exports = {
             {
                 test: /\.scss$/,
                 loaders: [
-                    'style-loader',
+                    'isomorphic-style-loader',
                     'css-loader?modules&-autoprefixer&importLoaders=1&localIdentName=[local]___[hash:base64:5]',
                     'postcss-loader',
                     'sass-loader',


### PR DESCRIPTION
This one allows rendering on the server side. Originally, I made some attempts to piggyback on the work at
https://github.com/abhirathore2006/react-image-lightbox-universal mentioned in #27, but it seemed like using ExtractTextPlugin brought some unnecessary complexity.

Instead, this change trades out style-loader for [isomorphic-style-loader](https://github.com/kriasoft/isomorphic-style-loader) and just embeds the CSS within the `LightBox` component itself.

I added a quick-and-dirty `npm run server-test` to kick out a server-rendered version of the `LightBox` component.

I have one linting warning for a line that got too long, but it might take a little refactor into smaller components since things are nested so deeply in a single component at this point. Not sure it should block merging SSR, but what do you think?