### PR TITLE
correction for pull request #66, use 'null' instead of '0'

### DIFF
--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -1321,8 +1321,8 @@ class ReactImageLightbox extends Component {
                 return;
             }
 
-            imageStyle.width = (isNaN(bestImageInfo.width)) ? 0 : bestImageInfo.width;
-            imageStyle.height = (isNaN(bestImageInfo.height)) ? 0 : bestImageInfo.height;
+            imageStyle.width = isNaN(bestImageInfo.width) ? null : bestImageInfo.width;
+            imageStyle.height = isNaN(bestImageInfo.height) ? null : bestImageInfo.height;
 
             const imageSrc = bestImageInfo.src;
             if (discourageDownloads) {


### PR DESCRIPTION
correcting a mistake from pull reequest #66, i intended to set the width and height property to 'null' but unfortunately wrote 0 -.- therefore #66 fixed #59 and #65 but the images height and width are not available for (yet) wont be displayed at all.