### PR TITLE
Modify transformations for better iOS Safari rendering

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -40,8 +40,6 @@ $maxCaptionHeight: 150px;
     bottom: 0;
     left: 0;
     margin: auto;
-    max-width: 100%;
-    max-height: 100%;
     -ms-content-zooming: none;
     -ms-user-select: none;
     -ms-touch-select: none;


### PR DESCRIPTION
Fixes #69.

~~@fritz-c I haven't actually had a chance to test this on an iPhone, but I believe this should make Safari render the image at full detail when zoomed in. I should be able to test this out on an iPhone later today, unless you can check it earlier.~~

@fritz-c Tested working on iPhone!

Also tested to make sure nothing broke in IE10. By the way, it seems to be perfectly usable in IE9 (just without animations) which is great!