### PR TITLE
Remove orange outline around viewer in Chrome on Android

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -12,6 +12,7 @@ $maxCaptionHeight: 150px;
 
 .outer {
   background-color: rgba(0, 0, 0, 0.85);
+  outline: none;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
Fixes #72.