### PR TITLE
add crossOrigin Options to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ keyRepeatLimit      | number | `180`          |          | Required interval of 
 keyRepeatKeyupBonus | number | `40`           |          | Amount of time (ms) restored after each keyup (makes rapid key presses slightly faster than holding down the key to navigate images)
 imageTitle          | node   |                |          | Image title (Descriptive element above image)
 imageCaption        | node   |                |          | Image caption (Descriptive element below image)
+imageCrossOrigin    | string |                |          | `CrossOrigin` attribute tu append to html image elements ([MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin))
 toolbarButtons      | node[] |                |          | Array of custom toolbar buttons
 reactModalStyle     | Object | `{}`           |          | Set `z-index` style, etc., for the parent react-modal ([react-modal style format](https://github.com/reactjs/react-modal#styles))
 imagePadding        | number | `10`           |          | Padding (px) between the edge of the window and the lightbox

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-lightbox",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
+++ b/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
@@ -10,6 +10,7 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
   discourageDownloads={false}
   enableZoom={true}
   imageCaption={null}
+  imageCrossOrigin={null}
   imagePadding={10}
   imageTitle={null}
   keyRepeatKeyupBonus={40}

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -1184,6 +1184,10 @@ class ReactImageLightbox extends Component {
     const that = this;
     const inMemoryImage = new Image();
 
+    if (this.props.imageCrossOrigin) {
+      inMemoryImage.crossOrigin = this.props.imageCrossOrigin;
+    }
+
     inMemoryImage.onerror = errorEvent => {
       this.props.onImageLoadError(imageSrc, srcType, errorEvent);
       done(errorEvent);
@@ -1314,6 +1318,7 @@ class ReactImageLightbox extends Component {
       toolbarButtons,
       reactModalStyle,
       onAfterOpen,
+      imageCrossOrigin,
     } = this.props;
     const { zoomLevel, offsetX, offsetY, isClosing } = this.state;
 
@@ -1439,6 +1444,7 @@ class ReactImageLightbox extends Component {
       } else {
         images.push(
           <img
+            { ...( imageCrossOrigin && { crossOrigin: imageCrossOrigin } ) }
             className={`${imageClass} ${styles.image}`}
             onDoubleClick={this.handleImageDoubleClick}
             onWheel={this.handleImageMouseWheel}
@@ -1779,6 +1785,9 @@ ReactImageLightbox.propTypes = {
   // Image caption
   imageCaption: PropTypes.node,
 
+  // Optional crossOrigin attribute
+  imageCrossOrigin: PropTypes.string,
+
   //-----------------------------
   // Lightbox style
   //-----------------------------
@@ -1824,6 +1833,7 @@ ReactImageLightbox.defaultProps = {
   discourageDownloads: false,
   enableZoom: true,
   imagePadding: 10,
+  imageCrossOrigin: null,
   keyRepeatKeyupBonus: 40,
   keyRepeatLimit: 180,
   mainSrcThumbnail: null,


### PR DESCRIPTION
This is a pull request to allow user to add or not the html5 attribute `crossorigin`.

By default, it won't affect anything.

If the props `imageCrossOrigin` is set, it will add the attribute to the `<img />` element and force the preloaded image to send `Origin` header also.

This PR is relative to this issue => #84 